### PR TITLE
Replace jimp with Canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "@zxing/library": "mattcollier/zxing-library",
     "delay": "^5.0.0",
-    "esm": "^3.2.25",
-    "jimp": "^0.16.1"
+    "esm": "^3.2.25"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/scan.js
+++ b/scan.js
@@ -1,33 +1,76 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
-import Jimp from 'jimp/es';
+// import Jimp from 'jimp/es'
 import {
   PDF417Reader,
   BinaryBitmap,
   HybridBinarizer,
-  RGBLuminanceSource
+  RGBLuminanceSource,
+  HTMLCanvasElementLuminanceSource
 } from '@zxing/library';
 import delay from 'delay';
 
+const DEGREE_TO_RADIANS = Math.PI / 180;
+
 export default async function scan({url}) {
-  const image = await Jimp.read({url});
-  image.grayscale();
-  return findPoints({image});
+  const img = await getImage({url});
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  // ctx.filter = 'grayscale(100)';
+  // const image = await Jimp.read({url});
+  // image.grayscale();
+  return await findPoints({canvas});
 }
 
-async function findPoints({image}) {
-  if(image.bitmap.width > 3000) {
-    image.resize(2000, Jimp.AUTO, Jimp.RESIZE_BICUBIC);
+async function getImage({url}) {
+  const reader = new FileReader();
+  const p = new Promise((resolve, reject) => {
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = reject;
+  });
+  const i = await fetch(url);
+  reader.readAsDataURL(await i.blob());
+  const imageData = await p;
+  const img = new Image();
+  img.src = imageData;
+
+  return img;
+}
+
+async function findPoints({canvas}) {
+  if(canvas.width > 3000) {
+    throw new Error('SCALE NOT IMPLEMENTED');
+    // image.resize(2000, Jimp.AUTO, Jimp.RESIZE_BICUBIC);
   }
+
   const rotations = [0, 180, 90, 180];
   for(const rotation of rotations) {
-    image.rotate(rotation);
-    for(let contrast = 0; contrast <= .20; contrast += .10) {
-      image.contrast(contrast);
-      const result = await tryImage({image});
+    console.log('TTTTTTTT', rotation);
+    if(rotation > 0) {
+      const ctx = canvas.getContext('2d');
+      ctx.rotate(rotation * DEGREE_TO_RADIANS);
+    }
+    const canvasClone = cloneCanvas(canvas);
+    for(let contrast = 100; contrast <= 120; contrast += 1) {
+      // const ctx = canvasClone.getContext('2d');
+      const c = contrast / 100;
+      console.log('CCCCCC', c);
+      const newCanvas = document.createElement('canvas');
+      newCanvas.width = canvasClone.width;
+      newCanvas.height = canvasClone.height;
+      const ctx2 = newCanvas.getContext('2d');
+      ctx2.filter = `contrast(${c})`;
+      ctx2.drawImage(canvasClone, 0, 0);
+      // image.contrast(contrast);
+      const result = await tryImage({canvas: newCanvas});
       if(result && result.points[0] && !result.points[0].includes(null)) {
-        const processedPoints = await processPoints({image, result});
+        console.log('111111111');
+        const processedPoints = await processPoints(
+          {canvas: newCanvas, result});
         if(processedPoints) {
           return processedPoints;
         }
@@ -38,16 +81,44 @@ async function findPoints({image}) {
   throw new Error('Scanning Error');
 }
 
-async function processPoints({image, result}) {
-  const croppedImage = cropImage({image, result});
-  const decodeResult = await decodeImage({image: croppedImage});
+function cloneCanvas(oldCanvas) {
+
+    //create a new canvas
+    var newCanvas = document.createElement('canvas');
+    var context = newCanvas.getContext('2d');
+
+    //set dimensions
+    newCanvas.width = oldCanvas.width;
+    newCanvas.height = oldCanvas.height;
+
+    //apply the old canvas to the new one
+    context.drawImage(oldCanvas, 0, 0);
+
+    //return the new canvas
+    return newCanvas;
+}
+
+async function processPoints({canvas, result}) {
+  const croppedImage = cropImage({canvas, result});
+  const decodeResult = await decodeImage({canvas: croppedImage});
   if(decodeResult.length === 1) {
     console.log(`SUCCESSFULLY DECODED`);
     return decodeResult[0];
   }
 }
 
-function cropImage({image, result}) {
+const cropCanvas = (sourceCanvas, left, top, width, height) => {
+  let destCanvas = document.createElement('canvas');
+  destCanvas.width = width;
+  destCanvas.height = height;
+  destCanvas.getContext("2d").drawImage(
+      sourceCanvas,
+      left, top, width, height,  // source rect with content to crop
+      0, 0, width, height);      // newCanvas, same size as source rect
+  return destCanvas;
+}
+
+function cropImage({canvas, result}) {
   const points = result.points[0];
   const topLeftX = points[0].x;
   const topLeftY = points[0].y;
@@ -60,30 +131,28 @@ function cropImage({image, result}) {
 
   const leftMin = Math.max(Math.min(bottomLeftX, topLeftX) - 50, 0);
   const rightMax = Math.min(
-    Math.max(topRightX, bottomRightX) + 50, image.bitmap.width);
+    Math.max(topRightX, bottomRightX) + 50, canvas.width);
   const topMin = Math.max(Math.min(topLeftY, topRightY) - 50, 0);
   const bottomMax = Math.min(
-    Math.max(bottomLeftY, bottomRightY) + 50, image.bitmap.height);
+    Math.max(bottomLeftY, bottomRightY) + 50, canvas.height);
   const height = bottomMax - topMin;
   const width = rightMax - leftMin;
-  const croppedImage = image.clone();
-  croppedImage.crop(leftMin, topMin, width, height);
+  // const croppedImage = image.clone();
+  const croppedImage = cropCanvas(canvas, leftMin, topMin, width, height);
+  // croppedImage.crop(leftMin, topMin, width, height);
   return croppedImage;
 }
 
-async function decodeImage({image}) {
+async function decodeImage({canvas}) {
   let result = [];
-  const pixels = computePixels({image});
   try {
     result = await Promise.race([
       (async () => {
-        const luminanceSource = new RGBLuminanceSource(
-          Int32Array.from(pixels), image.bitmap.width,
-          image.bitmap.height,
-        );
+        const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
         const binaryBitmap = new BinaryBitmap(new HybridBinarizer(
           luminanceSource));
         const r = await PDF417Reader.decode(binaryBitmap);
+        console.log('RRRRRRRRRRRRR', r);
         return r;
       })(),
       delay(5),
@@ -94,16 +163,13 @@ async function decodeImage({image}) {
   return result;
 }
 
-async function tryImage({image}) {
+async function tryImage({canvas}) {
   let result;
-  const pixels = computePixels({image});
+  // const pixels = computePixels({image});
   try {
     result = await Promise.race([
       (async () => {
-        const luminanceSource = new RGBLuminanceSource(
-          Int32Array.from(pixels), image.bitmap.width,
-          image.bitmap.height,
-        );
+        const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
         const binaryBitmap = new BinaryBitmap(new HybridBinarizer(
           luminanceSource));
         const r = await PDF417Reader.detect(binaryBitmap);

--- a/scan.js
+++ b/scan.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
+/* eslint-env browser */
 import {
   PDF417Reader,
   BinaryBitmap,
@@ -9,191 +10,177 @@ import {
 } from '@zxing/library';
 import delay from 'delay';
 
-const DEGREE_TO_RADIANS = Math.PI / 180;
+// default timeout is 16 ms because it is the amount of time a single frame
+// would be rendered in a 60 frames/sec video, i.e., it should not be
+// perceptible to a human
+const DEFAULT_TIMEOUT = 16;
+// for converting degrees to radians for rotation
+const RADIANS_PER_DEGREE = Math.PI / 180;
+// number of pixels to allow around a detected PDF417 barcode bounding box
+const BOX_ERROR = 50;
 
 export default async function scan({url}) {
-  const img = await getImage({url});
+  const image = await _getImage({url});
+
+  // create working square canvas with max width/height to enable rotation of
+  // images within it
   const canvas = document.createElement('canvas');
-  canvas.width = img.width;
-  canvas.height = img.height;
+  const dimension = Math.max(image.width, image.height);
+  canvas.width = canvas.height = dimension;
+  // enable image smoothing as it seems to improve scan success rate
   const ctx = canvas.getContext('2d');
-  ctx.drawImage(img, 0, 0);
-  return await findPoints({canvas});
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+
+  // scan in bands of high/low width scaled images
+  const highWidth = Math.min(image.width - 11, 2000);
+  const lowWidth = Math.min(image.width / 2, 1000);
+
+  // create widths to scale the image to by incrementally adding two pixels to
+  // the width that defines each band; this increases the likelihood that the
+  // scaling algorithm will flip pixels in the barcode and yield a success
+  const widths = [highWidth, lowWidth];
+  for(let i = 0, hw = highWidth + 2, lw = lowWidth + 2;
+    i < 5; ++i, ++hw, ++lw) {
+    widths.push(hw);
+    widths.push(lw);
+  }
+
+  let err;
+  const rotations = [0, 90];
+  for(const rotation of rotations) {
+    for(const width of widths) {
+      // render the image with the given width and rotation
+      _render({canvas, image, width, rotation});
+
+      // try to detect the PDF417 barcode
+      try {
+        const result = await _getBarcode({canvas});
+        if(result) {
+          return result;
+        }
+      } catch(e) {
+        err = e;
+      }
+    }
+  }
+  if(err) {
+    throw err;
+  }
+
+  return null;
 }
 
-async function getImage({url}) {
+async function _getImage({url}) {
   const reader = new FileReader();
   const p = new Promise((resolve, reject) => {
     reader.onloadend = () => resolve(reader.result);
     reader.onerror = reject;
   });
-  const i = await fetch(url);
-  reader.readAsDataURL(await i.blob());
+  const response = await fetch(url);
+  reader.readAsDataURL(await response.blob());
   const imageData = await p;
-  const img = new Image();
-  img.src = imageData;
-
-  return img;
+  const image = new Image();
+  image.src = imageData;
+  return image;
 }
 
-async function findPoints({canvas}) {
-  if(canvas.width > 3000) {
-    console.log('SCALE NOT IMPLEMENTED');
-    // image.resize(2000, Jimp.AUTO, Jimp.RESIZE_BICUBIC);
+async function _getBarcode({canvas}) {
+  const result = await _detectWithTimeout({canvas});
+  if(!result) {
+    // no barcode detected
+    return null;
   }
 
-  const rotations = [0, 90, 180, 270];
-  for(const rotation of rotations) {
-    await delay(100);
-    let rotateCanvas = canvas;
-    if(rotation > 0) {
-      // rotateCanvas = document.getElementById('myCanvas');
-      rotateCanvas = document.createElement('canvas');
-      if(rotation === 90 || rotation === 270) {
-        rotateCanvas.width = canvas.height;
-        rotateCanvas.height = canvas.width;
-      } else {
-        rotateCanvas.width = canvas.width;
-        rotateCanvas.height = canvas.height;
-      }
-      const ctx = rotateCanvas.getContext('2d');
-      const cx = canvas.width / 2;
-      const cy = canvas.height / 2;
-      ctx.fillRect(0, 0, rotateCanvas.width, rotateCanvas.height);
-      ctx.translate(cx, cy);
-      ctx.rotate(rotation * DEGREE_TO_RADIANS);
-      if(rotation === 90) {
-        ctx.translate(-canvas.height / 2, -canvas.width);
-      } else if(rotation === 270) {
-        ctx.translate(-canvas.width / 4, -canvas.width / 2);
-      } else {
-        ctx.translate(-cx, -cy);
-      }
-      ctx.drawImage(canvas, 0, 0);
-    }
-    const canvasClone = cloneCanvas(rotateCanvas);
-    for(let contrast = 100; contrast <= 120; contrast += 2) {
-      const c = contrast / 100;
-      const newCanvas = document.createElement('canvas');
-      newCanvas.width = canvasClone.width;
-      newCanvas.height = canvasClone.height;
-      const ctx2 = newCanvas.getContext('2d');
-      ctx2.filter = `contrast(${c})`;
-      ctx2.drawImage(canvasClone, 0, 0);
-      // image.contrast(contrast);
-      const result = await tryImage({canvas: newCanvas});
-      if(result && result.points[0] && !result.points[0].includes(null)) {
-        const processedPoints = await processPoints(
-          {canvas: newCanvas, result});
-        if(processedPoints) {
-          // enable to display successfully scanned canvas
-          // document.body.appendChild(newCanvas);
-          return processedPoints;
-        }
-        continue;
-      }
-    }
+  // crop barcode and decode it
+  const croppedImage = _crop({canvas, result});
+  const decoded = await _decodeWithTimeout({canvas: croppedImage});
+  if(!(decoded && decoded.length === 1)) {
+    // no barcode decoded
+    return false;
   }
-  throw new Error('Scanning Error');
+
+  return decoded[0];
 }
 
-function cloneCanvas(oldCanvas) {
+function _crop({canvas, result}) {
+  // destructure result into barcode bounding box coordinates
+  const {points: [[tl, bl, tr, br]]} = result;
 
-    //create a new canvas
-    var newCanvas = document.createElement('canvas');
-    var context = newCanvas.getContext('2d');
+  // calculate bounding box with some error margin
+  const left = Math.max(Math.min(bl.x, tl.x) - BOX_ERROR, 0);
+  const right = Math.min(Math.max(tr.x, br.x) + BOX_ERROR, canvas.width);
+  const top = Math.max(Math.min(tl.y, tr.y) - BOX_ERROR, 0);
+  const bottom = Math.min(Math.max(bl.y, br.y) + BOX_ERROR, canvas.height);
+  const height = bottom - top;
+  const width = right - left;
 
-    //set dimensions
-    newCanvas.width = oldCanvas.width;
-    newCanvas.height = oldCanvas.height;
-
-    //apply the old canvas to the new one
-    context.drawImage(oldCanvas, 0, 0);
-
-    //return the new canvas
-    return newCanvas;
-}
-
-async function processPoints({canvas, result}) {
-  const croppedImage = cropImage({canvas, result});
-  const decodeResult = await decodeImage({canvas: croppedImage});
-  if(decodeResult.length === 1) {
-    console.log(`SUCCESSFULLY DECODED`);
-    return decodeResult[0];
-  }
-}
-
-const cropCanvas = (sourceCanvas, left, top, width, height) => {
-  let destCanvas = document.createElement('canvas');
+  // write the contents of bounding box to a new canvas
+  const destCanvas = document.createElement('canvas');
   destCanvas.width = width;
   destCanvas.height = height;
-  destCanvas.getContext("2d").drawImage(
-      sourceCanvas,
-      left, top, width, height,  // source rect with content to crop
-      0, 0, width, height);      // newCanvas, same size as source rect
+  destCanvas.getContext('2d').drawImage(
+    canvas,
+    // source rect with content to crop
+    left, top, width, height,
+    // destination rect, same size as source rect
+    0, 0, width, height);
   return destCanvas;
 }
 
-function cropImage({canvas, result}) {
-  const points = result.points[0];
-  const topLeftX = points[0].x;
-  const topLeftY = points[0].y;
-  const topRightX = points[2].x;
-  const topRightY = points[2].y;
-  const bottomLeftX = points[1].x;
-  const bottomLeftY = points[1].y;
-  const bottomRightX = points[3].x;
-  const bottomRightY = points[3].y;
-
-  const leftMin = Math.max(Math.min(bottomLeftX, topLeftX) - 50, 0);
-  const rightMax = Math.min(
-    Math.max(topRightX, bottomRightX) + 50, canvas.width);
-  const topMin = Math.max(Math.min(topLeftY, topRightY) - 50, 0);
-  const bottomMax = Math.min(
-    Math.max(bottomLeftY, bottomRightY) + 50, canvas.height);
-  const height = bottomMax - topMin;
-  const width = rightMax - leftMin;
-  // const croppedImage = image.clone();
-  const croppedImage = cropCanvas(canvas, leftMin, topMin, width, height);
-  // croppedImage.crop(leftMin, topMin, width, height);
-  return croppedImage;
+async function _decode({canvas}) {
+  const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
+  const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
+  return PDF417Reader.decode(binaryBitmap);
 }
 
-async function decodeImage({canvas}) {
-  let result = [];
-  try {
-    result = await Promise.race([
-      (async () => {
-        const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
-        const binaryBitmap = new BinaryBitmap(new HybridBinarizer(
-          luminanceSource));
-        const r = await PDF417Reader.decode(binaryBitmap);
-        return r;
-      })(),
-      delay(5),
-    ]);
-  } catch(e) {
-    console.error(`Decode Error: ${e.toString()}`);
-  }
-  return result;
+async function _decodeWithTimeout({canvas, timeout = DEFAULT_TIMEOUT}) {
+  return Promise.race([_decode({canvas}), delay(timeout)]);
 }
 
-async function tryImage({canvas}) {
-  let result;
-  // const pixels = computePixels({image});
-  try {
-    result = await Promise.race([
-      (async () => {
-        const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
-        const binaryBitmap = new BinaryBitmap(new HybridBinarizer(
-          luminanceSource));
-        const r = await PDF417Reader.detect(binaryBitmap);
-        return r;
-      })(),
-      delay(5),
-    ]);
-  } catch(e) {
-    console.error(`Detection Error: ${e.toString()}`);
+async function _detect({canvas}) {
+  const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
+  const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
+  const result = await PDF417Reader.detect(binaryBitmap);
+  if(result && result.points[0] && !result.points[0].includes(null)) {
+    return result;
   }
-  return result;
+  // no barcode detected
+  return null;
+}
+
+async function _detectWithTimeout({canvas, timeout = DEFAULT_TIMEOUT}) {
+  return Promise.race([_detect({canvas}), delay(timeout)]);
+}
+
+async function _render({canvas, image, width, rotation}) {
+  // reset 2d transform and clear canvas
+  const ctx = canvas.getContext('2d');
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // coordinates for the center of the image
+  const cx = image.width / 2;
+  const cy = image.height / 2;
+
+  // determine scale for image
+  let scale = 1;
+  if(image.width > width) {
+    scale = width / image.width;
+  }
+
+  // set transform to prepare to scale and rotate the image; the horizontal
+  // and vertical scaling is the same and we move to the center of the image
+  // for rotation around it
+  ctx.setTransform(scale, 0, 0, scale, cx, cy);
+
+  // perform rotation, if any
+  if(rotation !== 0) {
+    // rotate given degrees (convert to radians)
+    ctx.rotate(rotation * RADIANS_PER_DEGREE);
+  }
+
+  // draw image, noting that the transformation has moved the context to the
+  // center of the image, so we must adjust the coordinates for where to draw
+  ctx.drawImage(image, -cx, -cy);
 }

--- a/scan.js
+++ b/scan.js
@@ -86,6 +86,8 @@ async function findPoints({canvas}) {
         const processedPoints = await processPoints(
           {canvas: newCanvas, result});
         if(processedPoints) {
+          // enable to display successfully scanned canvas
+          // document.body.appendChild(newCanvas);
           return processedPoints;
         }
         continue;


### PR DESCRIPTION
Creating PR to record progress here.  This will need some additional testing and polish before it's reading for a 1.0 release.

This performs very well and has high success rate for me with my collection of test images using desktop browsers. @JoshDunnDev is going to be doing additional testing soon.

I'll note that zxing does a grayscale conversion internally already, so there is no need to do that in our code.

One downside to using canvas filters is that Safari has no support on desktop/mobile for the filter APIs.  The easiest thing to do for Safari is to just skip any contrast adjustments on that platform.  I think this would be a fine solution for starters.  Contrast adjustments are not necessary in the common case anyway, and they are not always helpful anyway.  I estimate that the contrast adjustment is only helpful for 5-10% of cases. 

This canvas implementation is the best of 3 implementations I tried:
- fabric.js
  - Fabric is a heavy weight dep at ~300K
  - The preliminary results I was seeing with contrast adjustments were inferior to canvas implementation, so I've shelved it. 
  - https://github.com/digitalbazaar/bedrock-web-pdf417/compare/initial...initial-fabric
- photon
  - dumpster fire
  - https://github.com/digitalbazaar/bedrock-web-pdf417/compare/initial...initial-photon 